### PR TITLE
Ignoring fails with create user

### DIFF
--- a/core/components/hybridauth/model/hybridauth/hybridauth.class.php
+++ b/core/components/hybridauth/model/hybridauth/hybridauth.class.php
@@ -211,7 +211,7 @@ class HybridAuth {
 				}
 				// Creating new user and adding this record to him
 				else {
-					$username = !empty($profile['displayName']) ? $profile['displayName'] : $profile['identifier'];
+					$username = !empty($profile['identifier']) ? trim($profile['identifier']) : rand(8,10);
 					if ($exists = $this->modx->getCount('haUser', array('username' => $username))) {
 						for ($i = 1; $i <= 10; $i++) {
 							$tmp = $username . $i;


### PR DESCRIPTION
If user name have a bad words, MODX is reject this user. Now username can be olnly ID or random number, may be this is not good idea, but 99% users can enter via HA on the site.
