### PR TITLE
Изменения уникального индификатора

### DIFF
--- a/core/components/hybridauth/model/hybridauth/lib/Providers/Vkontakte.php
+++ b/core/components/hybridauth/model/hybridauth/lib/Providers/Vkontakte.php
@@ -88,7 +88,7 @@ class Hybrid_Providers_Vkontakte extends Hybrid_Provider_Model_OAuth2
 		}
 
 		$response = $response->response[0];
-		$this->user->profile->identifier    = (property_exists($response,'uid'))?$response->uid:"";
+		$this->user->profile->identifier    = (property_exists($response,'uid'))?$response->screen_name:"";
 		$this->user->profile->firstName     = (property_exists($response,'first_name'))?$response->first_name:"";
 		$this->user->profile->lastName      = (property_exists($response,'last_name'))?$response->last_name:"";
 		$this->user->profile->displayName   = (property_exists($response,'nickname'))?$response->nickname:"";


### PR DESCRIPTION
Вместо uid, использовать screen_name. При регистрации с Вконтакте username получает uid пользователя, а screen_name это как раз ник пользователя,если он есть а это уникальная страница. Если она не заполнена то возвращается тот же uid тока с добавлением "id". 
В итоге мы имеем человеческий ник если screen_name заполнен, или тот же набор цифр(uid) если его нет.
