### PR TITLE
Added additional check for instagram fullname field

### DIFF
--- a/core/components/hybridauth/model/hybridauth/hybridauth.class.php
+++ b/core/components/hybridauth/model/hybridauth/hybridauth.class.php
@@ -271,6 +271,9 @@ class HybridAuth {
 						'provider' => $profile,
 						'groups' => $this->config['groups'],
 					);
+					if (empty($arr['fullname']) && isset($profile['displayName'])) {
+					    $arr['fullname'] = $profile['displayName']; // Instagram
+					}
 					if (!$this->modx->getOption('ha.register_users', null, true)) {
 						$_SESSION['HA']['error'] = $this->modx->lexicon('ha_register_disabled');
 					}


### PR DESCRIPTION
При логине через инстаграм имя юзера полное передается, но в другом ключе лежит в профиле в исходной библиотеке. Добавил дополнительную проверку