### PR TITLE
Fixed #17 after updated HybridAuth core to 2.3.0

### DIFF
--- a/_build/build.config.php
+++ b/_build/build.config.php
@@ -3,7 +3,7 @@
 define('PKG_NAME','HybridAuth');
 define('PKG_NAME_LOWER',strtolower(PKG_NAME));
 
-define('PKG_VERSION','1.1.0');
+define('PKG_VERSION','1.1.1');
 define('PKG_RELEASE','pl');
 define('PKG_AUTO_INSTALL', true);
 

--- a/core/components/hybridauth/docs/changelog.txt
+++ b/core/components/hybridauth/docs/changelog.txt
@@ -1,5 +1,9 @@
 Changelog for HybridAuth.
 
+1.1.1 pl
+==============
+- [#17] Fixed work with enabled php-apc after updated HybridAuth core to version 2.3.0.
+
 1.1.0 pl
 ==============
 - Updated HybridAuth core to version 2.3.0.

--- a/core/components/hybridauth/model/hybridauth/lib/Auth.php
+++ b/core/components/hybridauth/model/hybridauth/lib/Auth.php
@@ -366,6 +366,7 @@ class Hybrid_Auth
 			echo '</html>'; 
 		}
 
+		@session_write_close();
 		die();
 	}
 

--- a/core/components/hybridauth/model/hybridauth/lib/Endpoint.php
+++ b/core/components/hybridauth/model/hybridauth/lib/Endpoint.php
@@ -68,6 +68,7 @@ class Hybrid_Endpoint {
 	{
 		$output = file_get_contents( dirname(__FILE__) . "/resources/openid_policy.html" ); 
 		print $output;
+		@session_write_close();
 		die();
 	}
 
@@ -88,6 +89,7 @@ class Hybrid_Endpoint {
 			file_get_contents( dirname(__FILE__) . "/resources/openid_xrds.xml" )
 		);
 		print $output;
+		@session_write_close();
 		die();
 	}
 
@@ -103,6 +105,7 @@ class Hybrid_Endpoint {
 			file_get_contents( dirname(__FILE__) . "/resources/openid_realm.html" )
 		); 
 		print $output;
+		@session_write_close();
 		die();
 	}
 
@@ -144,6 +147,7 @@ class Hybrid_Endpoint {
 			$hauth->returnToCallbackUrl();
 		}
 
+		@session_write_close();
 		die();
 	}
 
@@ -181,6 +185,7 @@ class Hybrid_Endpoint {
 		Hybrid_Logger::info( "Endpoint: job done. retrun to callback url." );
 
 		$hauth->returnToCallbackUrl();
+		@session_write_close();
 		die();
 	}
 


### PR DESCRIPTION
[#17] Fixed work with enabled php-apc after updated HybridAuth core to
version 2.3.0.
