### PR TITLE
Update create and update service processors to prevent 500 error

### DIFF
--- a/core/components/hybridauth/processors/web/service/create.class.php
+++ b/core/components/hybridauth/processors/web/service/create.class.php
@@ -17,9 +17,9 @@ class haUserServiceCreateProcessor extends modObjectCreateProcessor
         foreach ($properties as $k => $v) {
             $k = strtolower($k);
             if (is_array($v)) {
-                foreach ($v as &$v2) {
-                    $v2 = $this->modx->stripTags($v2);
-                }
+                array_walk_recursive($v, function ($value, $key, $modx) {
+                    $value = $modx->stripTags($value);
+                }, $this->modx);
                 $properties[$k] = $v;
             } else {
                 $properties[$k] = $this->modx->stripTags($v);

--- a/core/components/hybridauth/processors/web/service/update.class.php
+++ b/core/components/hybridauth/processors/web/service/update.class.php
@@ -17,9 +17,9 @@ class haUserServiceUpdateProcessor extends modObjectUpdateProcessor
         foreach ($properties as $k => $v) {
             $k = strtolower($k);
             if (is_array($v)) {
-                foreach ($v as &$v2) {
-                    $v2 = $this->modx->stripTags($v2);
-                }
+                array_walk_recursive($v, function ($value, $key, $modx) {
+                    $value = $modx->stripTags($value);
+                }, $this->modx);
                 $properties[$k] = $v;
             } else {
                 $properties[$k] = $this->modx->stripTags($v);


### PR DESCRIPTION
Ensures that services that return properties having nested arrays are supported, preventing 500 errors on the front end when attempting to login.

### Why is it needed?
To support more strict standards enforced by PHP 8+. If a service provides properties where some values contain an array, the call to $modx->stripTags() throws a type error resulting in a 500 server error.

### How to test
Verify that a built in service works as expected. Also, if needed, alter a service's properties to add at least one key whose value is an array to verify no errors occur.

### Related issue(s)/PR(s)
May relate to #46
