### PR TITLE
fix(schema): Remove FULLTEXT index from ha_user_services.extended

### DIFF
--- a/core/components/hybridauth/model/hybridauth/mysql/hauserservice.map.inc.php
+++ b/core/components/hybridauth/model/hybridauth/mysql/hauserservice.map.inc.php
@@ -222,7 +222,6 @@ $xpdo_meta_map['haUserService'] = array(
                     'dbtype' => 'text',
                     'phptype' => 'json',
                     'null' => true,
-                    'index' => 'fulltext',
                 ),
         ),
     'indexes' =>

--- a/core/components/hybridauth/model/schema/hybridauth.mysql.schema.xml
+++ b/core/components/hybridauth/model/schema/hybridauth.mysql.schema.xml
@@ -36,7 +36,7 @@
         <field key="city" dbtype="varchar" precision="100" phptype="string" null="true"/>
         <field key="zip" dbtype="varchar" precision="25" phptype="string" null="true"/>
 
-        <field key="extended" dbtype="text" phptype="json" null="true" index="fulltext"/>
+        <field key="extended" dbtype="text" phptype="json" null="true"/>
 
         <index alias="unique_fields" name="unique_fields" primary="false" unique="true" type="BTREE">
             <column key="internalKey" length="" collation="A" null="false"/>


### PR DESCRIPTION
Remove the unused FULLTEXT index on `ha_user_services.extended`.

Install fails when xPDO creates the table with `ENGINE=InnoDB` and `FULLTEXT INDEX extended`: MySQL returns error 1214 on builds that do not support InnoDB FULLTEXT. The field holds JSON; the codebase never runs `MATCH ... AGAINST` against it.

Fixes #51