### PR TITLE
fix(hybridauth): fix MODX 3 processor and model-loading auth errors

### DIFF
--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -36,6 +36,17 @@ $modx->setLogLevel(modX::LOG_LEVEL_INFO);
 $modx->setLogTarget('ECHO');
 $modx->getService('error', 'error.modError');
 
+// MODX3 namespaces compatibility for legacy builder script.
+if (!class_exists('modPackageBuilder') && class_exists(\MODX\Revolution\Transport\modPackageBuilder::class)) {
+    class_alias(\MODX\Revolution\Transport\modPackageBuilder::class, 'modPackageBuilder');
+}
+if (!class_exists('xPDOTransport') && class_exists(\xPDO\Transport\xPDOTransport::class)) {
+    class_alias(\xPDO\Transport\xPDOTransport::class, 'xPDOTransport');
+}
+if (!class_exists('xPDO') && class_exists(\xPDO\xPDO::class)) {
+    class_alias(\xPDO\xPDO::class, 'xPDO');
+}
+
 /* vendor/ is gitignored; transport must include it (#54) */
 ensureComposerVendor($sources['source_core'], $modx);
 

--- a/core/components/hybridauth/elements/snippets/snippet.haprofile.php
+++ b/core/components/hybridauth/elements/snippets/snippet.haprofile.php
@@ -77,7 +77,10 @@ if ((!empty($_REQUEST['action']) && strtolower($_REQUEST['action']) == 'updatepr
 }
 
 $add = array();
-if ($services = $modx->user->getMany('Services')) {
+$services = $modx->getCollection('haUserService', array(
+    'internalKey' => (int)$modx->user->id,
+));
+if (!empty($services)) {
     /** @var haUserService $service */
     foreach ($services as $service) {
         $add = array_merge($add, $service->toArray(strtolower($service->get('provider') . '.')));

--- a/core/components/hybridauth/elements/snippets/snippet.hybridauth.php
+++ b/core/components/hybridauth/elements/snippets/snippet.hybridauth.php
@@ -41,7 +41,10 @@ if (!empty($_SESSION['HybridAuth']['error'])) {
 
 if ($modx->user->isAuthenticated($modx->context->key)) {
     $add = array();
-    if ($services = $modx->user->getMany('Services')) {
+    $services = $modx->getCollection('haUserService', array(
+        'internalKey' => (int)$modx->user->id,
+    ));
+    if (!empty($services)) {
         /** @var haUserService $service */
         foreach ($services as $service) {
             $add = array_merge($add, $service->toArray(strtolower($service->get('provider') . '.')));

--- a/core/components/hybridauth/model/hybridauth/hybridauth.class.php
+++ b/core/components/hybridauth/model/hybridauth/hybridauth.class.php
@@ -12,6 +12,8 @@ class HybridAuth
     public $adapters = [];
     /** @var array $initialized */
     public $initialized = [];
+    /** @var bool $modelLoaded */
+    protected $modelLoaded = false;
 
 
     public function __construct(modX $modx, array $config = [])
@@ -41,8 +43,37 @@ class HybridAuth
             'postHooks' => '',
         ], $config);
 
+        $this->ensureModelPackageLoaded();
+
         $this->loadHybridAuth();
         $_SESSION['HybridAuth'][$this->modx->context->key] = $this->config;
+    }
+
+
+    /**
+     * Ensure xPDO package metadata and classes are loaded for haUserService.
+     *
+     * @return bool
+     */
+    protected function ensureModelPackageLoaded()
+    {
+        if ($this->modelLoaded) {
+            return true;
+        }
+
+        $modelPath = rtrim($this->config['modelPath'], '/') . '/';
+        $this->modx->setPackage('hybridauth', $modelPath);
+
+        if (!$this->modx->loadClass('haUserService', $modelPath . 'hybridauth/', true, false)) {
+            $this->modx->log(
+                modX::LOG_LEVEL_ERROR,
+                '[HybridAuth] Unable to load class haUserService from ' . $modelPath . 'hybridauth/'
+            );
+            return false;
+        }
+
+        $this->modelLoaded = true;
+        return true;
     }
 
 
@@ -300,6 +331,12 @@ class HybridAuth
      */
     protected function processOAuthProfile($provider, array $profile)
     {
+        if (!$this->ensureModelPackageLoaded()) {
+            $_SESSION['HybridAuth']['error'] = 'hauserservice_class_not_found';
+            $this->Refresh('login');
+            return;
+        }
+
         $profile['provider'] = $provider;
 
         $haRegistered = false;
@@ -576,6 +613,14 @@ class HybridAuth
             $this->exceptionHandler($e);
         }
 
+        // Avoid running MODX logout processor for anonymous requests.
+        // It may trigger permission checks and noisy SQL errors in some setups.
+        if (!$this->modx->user->isAuthenticated($this->modx->context->key)) {
+            unset($_SESSION['HybridAuth']['verified'], $_SESSION['HybridAuth']['error']);
+            $this->Refresh('logout');
+            return;
+        }
+
         $logout_data = [];
         if (!empty($this->config['loginContext'])) {
             $logout_data['login_context'] = $this->config['loginContext'];
@@ -587,6 +632,10 @@ class HybridAuth
         $response = $this->modx->runProcessor('security/logout', $logout_data);
         if ($response->isError()) {
             $msg = implode(', ', $response->getAllErrors());
+            if ($msg === 'not_logged_in') {
+                $this->Refresh('logout');
+                return;
+            }
             $this->modx->log(
                 modX::LOG_LEVEL_ERROR,
                 '[HybridAuth] logout error. Username: ' . $this->modx->user->get('username') . ', uid: ' . $msg
@@ -704,6 +753,8 @@ class HybridAuth
         if (empty($this->adapters)) {
             return '';
         }
+
+        $this->ensureModelPackageLoaded();
 
         $output = '';
         $url = $this->getUrl();

--- a/core/components/hybridauth/model/hybridauth/metadata.mysql.php
+++ b/core/components/hybridauth/model/hybridauth/metadata.mysql.php
@@ -7,16 +7,7 @@ $xpdo_meta_map = array(
         ),
 );
 
-// Guard: on PHP 8+ writing into a missing map key fatals the manager (#45, #46).
-if (isset($this->map['modUser']) && is_array($this->map['modUser'])) {
-    if (!isset($this->map['modUser']['composites']) || !is_array($this->map['modUser']['composites'])) {
-        $this->map['modUser']['composites'] = array();
-    }
-    $this->map['modUser']['composites']['Services'] = array(
-        'class' => 'haUserService',
-        'local' => 'id',
-        'foreign' => 'internalKey',
-        'cardinality' => 'many',
-        'owner' => 'local',
-    );
-}
+// Do not mutate $this->map at runtime here.
+// On MODX 3 + xPDOMap (ArrayAccess), nested map writes can emit
+// "Indirect modification of overloaded element ... has no effect".
+// Services are loaded explicitly via haUserService queries in snippets.

--- a/core/components/hybridauth/processors/web/user/create.class.php
+++ b/core/components/hybridauth/processors/web/user/create.class.php
@@ -1,14 +1,22 @@
 <?php
 
-use MODX\Revolution\Processors\Security\User\Create as UserCreateProcessor;
-
-if (!class_exists('modUserCreateProcessor', false)) {
-    class modUserCreateProcessor extends UserCreateProcessor
-    {
+if (!class_exists('haUserCreateBaseProcessor', false)) {
+    if (class_exists('modUserCreateProcessor')) {
+        class haUserCreateBaseProcessor extends modUserCreateProcessor
+        {
+        }
+    } elseif (class_exists(\MODX\Revolution\Processors\Security\User\Create::class)) {
+        class haUserCreateBaseProcessor extends \MODX\Revolution\Processors\Security\User\Create
+        {
+        }
+    } else {
+        class haUserCreateBaseProcessor extends modObjectCreateProcessor
+        {
+        }
     }
 }
 
-class haUserCreateProcessor extends modUserCreateProcessor
+class haUserCreateProcessor extends haUserCreateBaseProcessor
 {
     public $classKey = 'modUser';
     public $languageTopics = array('core:default', 'core:user');

--- a/core/components/hybridauth/processors/web/user/update.class.php
+++ b/core/components/hybridauth/processors/web/user/update.class.php
@@ -1,14 +1,22 @@
 <?php
 
-use MODX\Revolution\Processors\Security\User\Update as UserUpdateProcessor;
-
-if (!class_exists('modUserUpdateProcessor', false)) {
-    class modUserUpdateProcessor extends UserUpdateProcessor
-    {
+if (!class_exists('haUserUpdateBaseProcessor', false)) {
+    if (class_exists('modUserUpdateProcessor')) {
+        class haUserUpdateBaseProcessor extends modUserUpdateProcessor
+        {
+        }
+    } elseif (class_exists(\MODX\Revolution\Processors\Security\User\Update::class)) {
+        class haUserUpdateBaseProcessor extends \MODX\Revolution\Processors\Security\User\Update
+        {
+        }
+    } else {
+        class haUserUpdateBaseProcessor extends modObjectUpdateProcessor
+        {
+        }
     }
 }
 
-class haUserUpdateProcessor extends modUserUpdateProcessor
+class haUserUpdateProcessor extends haUserUpdateBaseProcessor
 {
     public $classKey = 'modUser';
     public $languageTopics = array('core:default', 'core:user');


### PR DESCRIPTION
Fix HybridAuth failures on MODX 3 during OAuth login/logout and profile rendering.

Several runtime paths relied on legacy MODX 2/xPDO assumptions: processor base classes were not always resolvable, package metadata for `haUserService` was not consistently loaded before queries, and logout for anonymous users still invoked the security logout processor. In practice this produced `Requested processor is invalid`, missing table class/name errors, and SQL fragments like `FROM AS haUserService`.

This change makes processor inheritance compatible with both MODX 2 and MODX 3 classes, enforces model package/class loading before service queries, and short-circuits anonymous logout handling to avoid noisy error paths. Snippets now load linked services via direct `haUserService` collection queries, and metadata runtime map mutation was removed to prevent `Indirect modification of overloaded element of xPDOMap` notices.

Also updates the build script with MODX 3 class aliases so transport packaging runs reliably in the current environment.