### PR TITLE
chore(ci): add GitHub release workflow for transport packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.2"
+          tools: composer
+          coverage: none
+
+      - name: Install component Hybridauth deps
+        run: composer install --no-interaction --no-dev --prefer-dist
+        working-directory: core/components/hybridauth
+
+      - name: Build transport package
+        run: php _build/build.transport.php
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: _packages/*.transport.zip

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 .vscode
 .DS_Store
+/_packages/
 config.core.php
 /core/components/hybridauth/vendor/
 

--- a/_build/build.config.php
+++ b/_build/build.config.php
@@ -6,7 +6,9 @@ define('PKG_NAME_LOWER', strtolower(PKG_NAME));
 
 const PKG_VERSION = '3.2.0';
 const PKG_RELEASE = 'pl';
-const PKG_AUTO_INSTALL = true;
+if (!defined('PKG_AUTO_INSTALL')) {
+    define('PKG_AUTO_INSTALL', getenv('GITHUB_ACTIONS') !== 'true');
+}
 
 // define paths
 if (isset($_SERVER['MODX_BASE_PATH'])) {

--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -280,6 +280,22 @@ $modx->log(modX::LOG_LEVEL_INFO, 'Added package attributes and setup options.');
 $modx->log(modX::LOG_LEVEL_INFO, 'Packing up transport package zip...');
 $builder->pack();
 
+$signature = $builder->getSignature();
+$builtZip = rtrim($modx->getOption('core_path'), '/') . '/packages/' . $signature . '.transport.zip';
+$artifactDir = dirname(__DIR__) . '/_packages';
+if (is_readable($builtZip)) {
+    if (!is_dir($artifactDir) && !mkdir($artifactDir, 0755, true) && !is_dir($artifactDir)) {
+        $modx->log(modX::LOG_LEVEL_ERROR, 'Could not create artifact directory: ' . $artifactDir);
+    } else {
+        $artifactPath = $artifactDir . '/' . basename($builtZip);
+        if (@copy($builtZip, $artifactPath)) {
+            $modx->log(modX::LOG_LEVEL_INFO, 'Copied transport package to ' . $artifactPath);
+        } else {
+            $modx->log(modX::LOG_LEVEL_ERROR, 'Could not copy transport package to ' . $artifactPath);
+        }
+    }
+}
+
 $mtime = microtime();
 $mtime = explode(" ", $mtime);
 $mtime = $mtime[1] + $mtime[0];
@@ -287,7 +303,6 @@ $tend = $mtime;
 $totalTime = ($tend - $tstart);
 $totalTime = sprintf("%2.4f s", $totalTime);
 
-$signature = $builder->getSignature();
 if (defined('PKG_AUTO_INSTALL') && PKG_AUTO_INSTALL) {
     $sig = explode('-', $signature);
     $versionSignature = explode('.', $sig[1]);


### PR DESCRIPTION
Add a tag-driven GitHub Actions release workflow modeled after Sendex.

On `v*` tags the workflow installs Hybridauth vendor dependencies, runs `_build/build.transport.php`, copies the resulting transport zip into `_packages/`, and attaches it to a GitHub Release. Build config skips PKG auto-install on `GITHUB_ACTIONS`, and the build script copies the artifact for upload.

This restores the release automation work from the removed `fix/modx3-compat-auth-flow` branch after PR #58 merged the MODX 3 compatibility fixes into master.